### PR TITLE
Use prop-types package instead of React.PropTypes

### DIFF
--- a/manual/keywords.md
+++ b/manual/keywords.md
@@ -2,13 +2,13 @@
 
 #### types - PropTypes
 
-* `number`:  `React.PropTypes.number` refer integer values
-* `boolean`: `React.PropTypes.bool` refer boolean type
-* `string`: `React.PropTypes.string` refer string type 
+* `number`:  `PropTypes.number` refer integer values
+* `boolean`: `PropTypes.bool` refer boolean type
+* `string`: `PropTypes.string` refer string type 
 * `Date` : refer Date type
-* `Map`: `React.PropTypes.object` json or object types which not include any function.
-* `Array`: `React.PropTypes.array` refer Array types
-* `any`: `React.PropTypes.any` // refer all tpyes
+* `Map`: `PropTypes.object` json or object types which not include any function.
+* `Array`: `PropTypes.array` refer Array types
+* `any`: `PropTypes.any` // refer all tpyes
 
 #### fieldNames
 
@@ -19,17 +19,17 @@
 
 #### props 
 
-* `value`: React.PropTypes.any // selected value or values
-* `style`: React.PropTypes.object // Style map for the component.
-* `label`: React.PropTypes.string // Label for the form control.
-* `items`: React.PropTypes.array // map array of options to render.
-* `multi`: React.PropTypes.bool multi select value
-* `valueField`: React.PropTypes.any // key of given map array `items`
-* `textField`: React.PropTypes.string // presented text of give map array `items`
-* `placeHolder`: React.PropTypes.string // displayed when there's no value
-* `onChange`: React.PropTypes.func // callback function when selected values changed
-* `onClick`: React.PropTypes.func // callback function when component clicked
-* `validations`: React.PropTypes.object // Validations for the component
-* `noResultsText`: React.PropTypes.string // presented message if any result not shown.
-* `disabled`: React.PropTypes.bool // disabled
-* `searchable`: React.PropTypes.bool // whether to enable searching feature or not
+* `value`: PropTypes.any // selected value or values
+* `style`: PropTypes.object // Style map for the component.
+* `label`: PropTypes.string // Label for the form control.
+* `items`: PropTypes.array // map array of options to render.
+* `multi`: PropTypes.bool multi select value
+* `valueField`: PropTypes.any // key of given map array `items`
+* `textField`: PropTypes.string // presented text of give map array `items`
+* `placeHolder`: PropTypes.string // displayed when there's no value
+* `onChange`: PropTypes.func // callback function when selected values changed
+* `onClick`: PropTypes.func // callback function when component clicked
+* `validations`: PropTypes.object // Validations for the component
+* `noResultsText`: PropTypes.string // presented message if any result not shown.
+* `disabled`: PropTypes.bool // disabled
+* `searchable`: PropTypes.bool // whether to enable searching feature or not

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "js-criteria": "1.0.6",
     "moment": "2.18.1",
     "nprogress": "0.2.0",
+    "prop-types": "^15.5.10",
     "react": "15.5.3",
     "react-addons-css-transition-group": "15.4.2",
     "react-addons-shallow-compare": "15.4.2",

--- a/site/Card.jsx
+++ b/site/Card.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent} from "robe-react-commons";
 import {Col, Collapse} from "react-bootstrap";
 import "./Card.css";
@@ -6,15 +7,15 @@ import "./Card.css";
 export default class Card extends ShallowComponent {
 
     static propTypes = {
-        xs: React.PropTypes.number,
-        sm: React.PropTypes.number,
-        md: React.PropTypes.number,
-        lg: React.PropTypes.number,
-        style: React.PropTypes.object,
-        border: React.PropTypes.bool,
-        margin: React.PropTypes.bool,
-        show: React.PropTypes.bool,
-        className: React.PropTypes.string
+        xs: PropTypes.number,
+        sm: PropTypes.number,
+        md: PropTypes.number,
+        lg: PropTypes.number,
+        style: PropTypes.object,
+        border: PropTypes.bool,
+        margin: PropTypes.bool,
+        show: PropTypes.bool,
+        className: PropTypes.string
     };
 
     static defaultProps = {

--- a/site/components/Renderer.jsx
+++ b/site/components/Renderer.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {Button, ButtonGroup, Panel, Table, Collapse, Tabs, Tab, Modal, OverlayTrigger, Tooltip} from "react-bootstrap";
 import {Maps, Application} from "robe-react-commons";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
@@ -19,27 +20,27 @@ export default class Renderer extends ShallowComponent {
         /**
          * Component name
          */
-        header: React.PropTypes.string,
+        header: PropTypes.string,
         /**
          * Component description
          */
-        desc: React.PropTypes.string,
+        desc: PropTypes.string,
         /**
          *
          */
-        alternatives: React.PropTypes.object,
+        alternatives: PropTypes.object,
         /**
          * Component Props Json
          */
-        json: React.PropTypes.object,
+        json: PropTypes.object,
         /**
          * Component Sample Code Object
          */
-        sample: React.PropTypes.object,
+        sample: PropTypes.object,
         /**
          * Component Sample Code string
          */
-        code: React.PropTypes.string
+        code: PropTypes.string
     };
 
     static defaultProps = {

--- a/site/docs/Renderer.jsx
+++ b/site/docs/Renderer.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {Button, Panel, Table} from "react-bootstrap";
 import {Maps} from "robe-react-commons";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
@@ -15,27 +16,27 @@ export default class Renderer extends ShallowComponent {
         /**
          * Component name
          */
-        header: React.PropTypes.string,
+        header: PropTypes.string,
         /**
          * Component description
          */
-        desc: React.PropTypes.string,
+        desc: PropTypes.string,
         /**
          *
          */
-        alternatives: React.PropTypes.object,
+        alternatives: PropTypes.object,
         /**
          * Component Props Json
          */
-        json: React.PropTypes.object,
+        json: PropTypes.object,
         /**
          * Component Sample Code Object
          */
-        sample: React.PropTypes.object,
+        sample: PropTypes.object,
         /**
          * Component Sample Code string
          */
-        code: React.PropTypes.string
+        code: PropTypes.string
     };
 
     static defaultProps = {

--- a/site/docs/samples/store/Snippet1.txt
+++ b/site/docs/samples/store/Snippet1.txt
@@ -1,10 +1,10 @@
 propTypes = {
-    idField: React.PropTypes.string,
-    importer: React.PropTypes.func,
-    loadProps: React.PropTypes.object,
-    result: React.PropTypes.shape({
-        data: React.PropTypes.array,
-        totalCount: React.PropTypes.number
+    idField: PropTypes.string,
+    importer: PropTypes.func,
+    loadProps: PropTypes.object,
+    result: PropTypes.shape({
+        data: PropTypes.array,
+        totalCount: PropTypes.number
     })
 }
 

--- a/site/sampleprojects/Renderer.jsx
+++ b/site/sampleprojects/Renderer.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {Col, Thumbnail, Label} from "react-bootstrap";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import FaIcon from "robe-react-ui/lib/faicon/FaIcon";
@@ -13,15 +14,15 @@ export default class Renderer extends ShallowComponent {
      */
     static propTypes = {
 
-        header: React.PropTypes.string,
+        header: PropTypes.string,
 
-        desc: React.PropTypes.string,
+        desc: PropTypes.string,
 
-        image: React.PropTypes.string,
+        image: PropTypes.string,
 
-        link: React.PropTypes.string,
+        link: PropTypes.string,
 
-        features: React.PropTypes.array
+        features: PropTypes.array
     };
 
     render(): Object {

--- a/src/Application.jsx
+++ b/src/Application.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 
 import {
     ShallowComponent,
@@ -15,7 +16,7 @@ export default class Application extends ShallowComponent {
      * @static
      */
     static propTypes: Map = {
-        language: React.PropTypes.string
+        language: PropTypes.string
     };
 
     /**
@@ -90,6 +91,3 @@ export default class Application extends ShallowComponent {
         }
     }
 }
-
-
-

--- a/src/buttons/Button.jsx
+++ b/src/buttons/Button.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import BButton from "react-bootstrap/lib/Button";
 import { ShallowComponent } from "robe-react-commons";
 import FaIcon from "../faicon/FaIcon";
@@ -20,28 +21,28 @@ export default class Button extends ShallowComponent {
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
 
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         * Event for synced operations.
         * Any operation will NOT trigger loading indicator and will act as normal button.
         */
-        onClick: React.PropTypes.func,
+        onClick: PropTypes.func,
 
         /**
         * Event for async operations (timeouts, AJAX calls).
         * Operation will trigger loading indicator.
         */
-        onClickAsync: React.PropTypes.func,
+        onClickAsync: PropTypes.func,
 
         /**
          * Loading indicator.
          */
-        loadingIndicator: React.PropTypes.oneOf(["fa-spinner", "fa-circle-o-notch", "fa-refresh", "fa-cog"])
+        loadingIndicator: PropTypes.oneOf(["fa-spinner", "fa-circle-o-notch", "fa-refresh", "fa-cog"])
 
     };
 

--- a/src/charts/AreaChart.jsx
+++ b/src/charts/AreaChart.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Generator, Class, Arrays, Maps} from "robe-react-commons";
 import "./AreaChart.css";
 import Legend from "./Legend";
@@ -9,23 +10,23 @@ export default class AreaChart extends ShallowComponent {
         /**
          * Width for chart as px
          */
-        width: React.PropTypes.number,
+        width: PropTypes.number,
         /**
          * Height for chart as px
          */
-        height: React.PropTypes.number,
+        height: PropTypes.number,
         /**
          * Data to be plotted on the chart
          */
-        data: React.PropTypes.array,
+        data: PropTypes.array,
         /**
          * Change to be made for the given data
          */
-        meta: React.PropTypes.array,
+        meta: PropTypes.array,
         /**
          * width the Legend
          */
-        legendWidth: React.PropTypes.number
+        legendWidth: PropTypes.number
     };
 
     static defaultProps = {

--- a/src/charts/BarChart.jsx
+++ b/src/charts/BarChart.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Generator, Class, Arrays, Maps} from "robe-react-commons";
 import "./BarChart.css";
 import Legend from "./Legend";
@@ -9,23 +10,23 @@ export default class BarChart extends ShallowComponent {
         /**
          * Width for chart as px
          */
-        width: React.PropTypes.number,
+        width: PropTypes.number,
         /**
          * Height for chart as px
          */
-        height: React.PropTypes.number,
+        height: PropTypes.number,
         /**
          * Data to be plotted on the chart
          */
-        data: React.PropTypes.array,
+        data: PropTypes.array,
         /**
          * Change to be made for the given data
          */
-        meta: React.PropTypes.array,
+        meta: PropTypes.array,
         /**
          * width the Legend
          */
-        legendWidth: React.PropTypes.number
+        legendWidth: PropTypes.number
     };
 
     static defaultProps = {

--- a/src/charts/Legend.jsx
+++ b/src/charts/Legend.jsx
@@ -1,13 +1,14 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import "./Legend.css";
 
 export default class Legend extends ShallowComponent {
 
     static propTypes = {
-        className: React.PropTypes.string,
-        width: React.PropTypes.number,
-        data: React.PropTypes.array,
+        className: PropTypes.string,
+        width: PropTypes.number,
+        data: PropTypes.array,
     };
 
     static defaultProps = {

--- a/src/charts/LineChart.jsx
+++ b/src/charts/LineChart.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Generator, Class, Arrays, Maps} from "robe-react-commons";
 import "./LineChart.css";
 import Legend from "./Legend";
@@ -9,23 +10,23 @@ export default class LineChart extends ShallowComponent {
         /**
          * Width for chart as px
          */
-        width: React.PropTypes.number,
+        width: PropTypes.number,
         /**
          * Height for chart as px
          */
-        height: React.PropTypes.number,
+        height: PropTypes.number,
         /**
          * Data to be plotted on the chart
          */
-        data: React.PropTypes.array,
+        data: PropTypes.array,
         /**
          * Change to be made for the given data
          */
-        meta: React.PropTypes.array,
+        meta: PropTypes.array,
         /**
          * width the Legend
          */
-        legendWidth: React.PropTypes.number
+        legendWidth: PropTypes.number
     };
 
     static defaultProps = {

--- a/src/charts/PieChart.jsx
+++ b/src/charts/PieChart.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Generator, Class, Arrays, Maps} from "robe-react-commons";
 import "./PieChart.css";
 import Legend from "./Legend";
@@ -9,15 +10,15 @@ export default class PieChart extends ShallowComponent {
         /**
          * Data to be plotted on the chart
          */
-        data: React.PropTypes.array,
+        data: PropTypes.array,
         /**
          * Size of chart as px
          */
-        size: React.PropTypes.number,
+        size: PropTypes.number,
         /**
          * width the Legend
          */
-        legendWidth: React.PropTypes.number
+        legendWidth: PropTypes.number
     };
 
     static defaultProps = {

--- a/src/charts/ScatterChart.jsx
+++ b/src/charts/ScatterChart.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Generator, Class, Arrays, Maps} from "robe-react-commons";
 import "./ScatterChart.css";
 import Legend from "./Legend";
@@ -9,23 +10,23 @@ export default class ScatterChart extends ShallowComponent {
         /**
          * Width for chart as px
          */
-        width: React.PropTypes.number,
+        width: PropTypes.number,
         /**
          * Height for chart as px
          */
-        height: React.PropTypes.number,
+        height: PropTypes.number,
         /**
          * Data to be plotted on the chart
          */
-        data: React.PropTypes.array,
+        data: PropTypes.array,
         /**
          * Change to be made for the given data
          */
-        meta: React.PropTypes.array,
+        meta: PropTypes.array,
         /**
          * width the Legend
          */
-        legendWidth: React.PropTypes.number
+        legendWidth: PropTypes.number
     };
 
     static defaultProps = {

--- a/src/checktree/CheckTree.jsx
+++ b/src/checktree/CheckTree.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Arrays from "robe-react-commons/lib/utils/Arrays";
 import Tree from "../tree/Tree";
@@ -23,27 +24,27 @@ export default class CheckTree extends ShallowComponent {
         /**
          * Data for the tree to view
          */
-        items: React.PropTypes.array.isRequired,
+        items: PropTypes.array.isRequired,
         /**
          * Text field of the data
          */
-        textField: React.PropTypes.string,
+        textField: PropTypes.string,
         /**
          * Value field of the data.
          */
-        valueField: React.PropTypes.string,
+        valueField: PropTypes.string,
         /**
          * Children field of the data.
          */
-        childrenField: React.PropTypes.string,
+        childrenField: PropTypes.string,
         /**
          * Checked items array.
          */
-        value: React.PropTypes.array,
+        value: PropTypes.array,
         /**
          * Valuen type
          */
-        valueType: React.PropTypes.oneOf(["number", "string"])
+        valueType: PropTypes.oneOf(["number", "string"])
     };
 
     static defaultProps = {

--- a/src/countdown/Countdown.jsx
+++ b/src/countdown/Countdown.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {Grid, Row, Col} from "react-bootstrap";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Application from "robe-react-commons/lib/application/Application";
@@ -20,58 +21,58 @@ export default class Countdown extends ShallowComponent {
         /**
          * Interval of the counter to tick.
          */
-        interval: React.PropTypes.number,
+        interval: PropTypes.number,
         /**
          *Starting value of the component in MS.
          */
-        value: React.PropTypes.number,
+        value: PropTypes.number,
         /**
          * Will fire when the counter finishes countdown. ( 0 )
          * No parameters.
          */
-        onComplete: React.PropTypes.func,
+        onComplete: PropTypes.func,
         /**
          * Will fire on every change of the value (not onComplete)
          * value as parameter.
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
 
         /**
          * Style of the counter.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
 
         /**
          * Props for days cell.
          */
-        days: React.PropTypes.shape({
-            visible: React.PropTypes.boolean,
-            label: React.PropTypes.string,
-            style: React.PropTypes.object
+        days: PropTypes.shape({
+            visible: PropTypes.boolean,
+            label: PropTypes.string,
+            style: PropTypes.object
         }),
         /**
          * Props for hours cell.
          */
-        hours: React.PropTypes.shape({
-            visible: React.PropTypes.boolean,
-            label: React.PropTypes.string,
-            style: React.PropTypes.object
+        hours: PropTypes.shape({
+            visible: PropTypes.boolean,
+            label: PropTypes.string,
+            style: PropTypes.object
         }),
         /**
          * Props for minutes cell.
          */
-        minutes: React.PropTypes.shape({
-            visible: React.PropTypes.boolean,
-            label: React.PropTypes.string,
-            style: React.PropTypes.object
+        minutes: PropTypes.shape({
+            visible: PropTypes.boolean,
+            label: PropTypes.string,
+            style: PropTypes.object
         }),
         /**
          * Props for seconds cell.
          */
-        seconds: React.PropTypes.shape({
-            visible: React.PropTypes.boolean,
-            label: React.PropTypes.string,
-            style: React.PropTypes.object
+        seconds: PropTypes.shape({
+            visible: PropTypes.boolean,
+            label: PropTypes.string,
+            style: PropTypes.object
         }),
     }
 

--- a/src/datafilter/DataFilter.jsx
+++ b/src/datafilter/DataFilter.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import {ShallowComponent, Application} from "robe-react-commons";
 import {Nav, NavItem, InputGroup, Overlay, Popover} from "react-bootstrap";
@@ -13,22 +14,22 @@ export default class DataFilter extends ShallowComponent {
         /**
          * placeholder text
          */
-        placeholder: React.PropTypes.string,
+        placeholder: PropTypes.string,
 
         /**
          * Is component visible or not
          */
-        visible: React.PropTypes.bool,
+        visible: PropTypes.bool,
 
         /**
          * Fired when filter is changed
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
 
         /**
          * Fields to populate selection list
          */
-        fields: React.PropTypes.array
+        fields: PropTypes.array
     };
 
     static defaultProps = {

--- a/src/datagrid/DataGrid.jsx
+++ b/src/datagrid/DataGrid.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import is from "is-js";
 import {Application, Store, StoreComponent, Maps, Assertions} from "robe-react-commons";
 import {Row, Col, Table} from "react-bootstrap";
@@ -24,97 +25,97 @@ export default class DataGrid extends StoreComponent {
         /**
          * Fields Configurations to show style on view.
          */
-        fields: React.PropTypes.array.isRequired,
+        fields: PropTypes.array.isRequired,
         /**
          * Holds extra props of components if need.
          */
-        propsOfFields: React.PropTypes.object,
+        propsOfFields: PropTypes.object,
         /**
          * set one store
          */
-        store: React.PropTypes.object.isRequired,
+        store: PropTypes.object.isRequired,
         /**
          * toolbar for create,edit,delete and custom buttons
          */
-        toolbar: React.PropTypes.array,
+        toolbar: PropTypes.array,
         /**
          * Callback for new button click
          */
-        onNewClick: React.PropTypes.func,
+        onNewClick: PropTypes.func,
         /**
          * Callback for edit button click
          */
-        onEditClick: React.PropTypes.func,
+        onEditClick: PropTypes.func,
         /**
          * Callback for delete button click
          */
-        onDeleteClick: React.PropTypes.func,
+        onDeleteClick: PropTypes.func,
         /**
          * show export data flag
          */
-        exportButton: React.PropTypes.bool,
+        exportButton: PropTypes.bool,
         /**
          * Make DataGrid as readonly
          */
-        editable: React.PropTypes.bool,
+        editable: PropTypes.bool,
         /**
          * ModalConfirm configuration
          */
-        modalConfirm: React.PropTypes.shape({
-            header: React.PropTypes.string,
-            message: React.PropTypes.string,
-            okButtonText: React.PropTypes.string,
-            cancelButtonText: React.PropTypes.string
+        modalConfirm: PropTypes.shape({
+            header: PropTypes.string,
+            message: PropTypes.string,
+            okButtonText: PropTypes.string,
+            cancelButtonText: PropTypes.string
         }),
         /**
          * Callback for row selection
          */
-        onSelection: React.PropTypes.func,
+        onSelection: PropTypes.func,
         /**
          * Enable pageable for DataGrid
          */
-        pageable: React.PropTypes.bool,
+        pageable: PropTypes.bool,
         /**
          * enable/disable searchable
          */
-        searchable: React.PropTypes.bool,
+        searchable: PropTypes.bool,
         /**
          * enable/disable DataFilter
          */
-        datafilter: React.PropTypes.bool,
+        datafilter: PropTypes.bool,
 
         /**
          * show/hide refresh button
          */
-        refreshable: React.PropTypes.bool,
+        refreshable: PropTypes.bool,
 
         /**
          * show/hide Page size buttons
          */
-        pageSizeButtons: React.PropTypes.array,
+        pageSizeButtons: PropTypes.array,
 
         /**
          * Render method for the row. Use for custom row templates
          */
-        rowRenderer: React.PropTypes.func,
+        rowRenderer: PropTypes.func,
 
         /**
          * Render method for the cell. Use for custom cell templates.
          * Default row template will call for every cell render event.
          */
-        cellRenderer: React.PropTypes.func,
+        cellRenderer: PropTypes.func,
 
         /**
          * Filter properties of the grid.
          */
-        filter: React.PropTypes.shape({
-            clearButtonText: React.PropTypes.string,
-            clearAllButtonText: React.PropTypes.string
+        filter: PropTypes.shape({
+            clearButtonText: PropTypes.string,
+            clearAllButtonText: PropTypes.string
         }),
         /**
          *Delay between last keystroke and requests.
          */
-        delay: React.PropTypes.number
+        delay: PropTypes.number
     };
     /**
      * static props

--- a/src/datagrid/DataGridBodyRow.jsx
+++ b/src/datagrid/DataGridBodyRow.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent } from "robe-react-commons";
 import is from "is-js";
 import ComponentManager from "../form/ComponentManager";
@@ -9,22 +10,22 @@ export default class DataTableBodyRow extends ShallowComponent {
      * @type {func}
      */
     static propTypes = {
-        onClick: React.PropTypes.func,
-        resources: React.PropTypes.object,
-        fields: React.PropTypes.array,
-        data: React.PropTypes.object,
-        onSelection: React.PropTypes.func,
+        onClick: PropTypes.func,
+        resources: PropTypes.object,
+        fields: PropTypes.array,
+        data: PropTypes.object,
+        onSelection: PropTypes.func,
 
         /**
          * Render method for the row. Use for custom row templates
          */
-        rowRenderer: React.PropTypes.func,
+        rowRenderer: PropTypes.func,
 
         /**
          * Render method for the cell. Use for custom cell templates.
          * Default row template will call for every cell render event.
          */
-        cellRenderer: React.PropTypes.func
+        cellRenderer: PropTypes.func
     };
 
     constructor(props: Object) {

--- a/src/datagrid/Header.jsx
+++ b/src/datagrid/Header.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 // import FaIcon from "../faicon/FaIcon";
 
@@ -12,21 +13,21 @@ export default class Header extends ShallowComponent {
         /**
          * Name of the column. Must be unique.
          */
-        name: React.PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
         /**
         * Field Configuration of the column.
         */
-        field: React.PropTypes.object.isRequired,
+        field: PropTypes.object.isRequired,
 
         /**
          * OnClick event for the filter button.
          * */
-        onFilterClick: React.PropTypes.func.isRequired,
+        onFilterClick: PropTypes.func.isRequired,
 
         /**
          * Filterable or not
          * */
-        filterable: React.PropTypes.bool
+        filterable: PropTypes.bool
 
     }
 

--- a/src/datagrid/Pagination.jsx
+++ b/src/datagrid/Pagination.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {
     Row,
     Col,
@@ -19,15 +20,15 @@ export default class Pagination extends ShallowComponent {
         /**
          * Fields Configurations to show style on view.
          */
-        activePage: React.PropTypes.number,
-        pageSize: React.PropTypes.number,
-        totalCount: React.PropTypes.number,
-        displayText: React.PropTypes.string,
-        emptyText: React.PropTypes.string,
-        onChange: React.PropTypes.func,
-        onPageSizeChange: React.PropTypes.func,
-        onRefresh: React.PropTypes.func,
-        pageSizeButtons: React.PropTypes.array,
+        activePage: PropTypes.number,
+        pageSize: PropTypes.number,
+        totalCount: PropTypes.number,
+        displayText: PropTypes.string,
+        emptyText: PropTypes.string,
+        onChange: PropTypes.func,
+        onPageSizeChange: PropTypes.func,
+        onRefresh: PropTypes.func,
+        pageSizeButtons: PropTypes.array,
 
     };
     static defaultProps = {

--- a/src/datagrid/filter/Filter.jsx
+++ b/src/datagrid/filter/Filter.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent, Objects } from "robe-react-commons";
 import * as Input from "../../inputs";
 import ComponentManager from "../../form/ComponentManager";
@@ -9,15 +10,15 @@ export default class Filter extends ShallowComponent {
         /**
          * Field properties to filter
          */
-        field: React.PropTypes.object.isRequired,
+        field: PropTypes.object.isRequired,
         /**
          *Value of the filter
          */
-        value: React.PropTypes.any,
+        value: PropTypes.any,
         /**
         *Delay between last keystroke and filter request.
         */
-        delay: React.PropTypes.number
+        delay: PropTypes.number
     }
 
     __refMap = {};

--- a/src/datagrid/filter/Filters.jsx
+++ b/src/datagrid/filter/Filters.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent } from "robe-react-commons";
 import { Popover, Overlay, Button, ButtonGroup } from "react-bootstrap";
 import Filter from "./Filter";
@@ -8,27 +9,27 @@ export default class Filters extends ShallowComponent {
         /**
          * Fields Configurations to show style on view.
          */
-        fields: React.PropTypes.array.isRequired,
+        fields: PropTypes.array.isRequired,
 
         /**
          * A map which contains names of the visible popups.
          */
-        visiblePopups: React.PropTypes.object.isRequired,
+        visiblePopups: PropTypes.object.isRequired,
 
         /**
          * Unique Id for the table.
          * It helps to open popups at the correct position in case of multiple table at one screen
          */
-        idCount: React.PropTypes.number.isRequired,
+        idCount: PropTypes.number.isRequired,
 
         /**
          *The event to trigger on every filter value update.
          */
-        onChange: React.PropTypes.func.isRequired,
+        onChange: PropTypes.func.isRequired,
         /**
          *Delay between last keystroke and filter request.
          */
-        delay: React.PropTypes.number
+        delay: PropTypes.number
     }
 
 

--- a/src/datagrid/toolbar/ActionButtons.jsx
+++ b/src/datagrid/toolbar/ActionButtons.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Maps from "robe-react-commons/lib/utils/Maps";
 import {
@@ -13,7 +14,7 @@ export default class ActionButtons extends ShallowComponent {
         /**
          * Fields Configurations to show style on view.
          */
-        visible: React.PropTypes.bool
+        visible: PropTypes.bool
     };
     static defaultProps = {
         visible: true,

--- a/src/datagrid/toolbar/SearchField.jsx
+++ b/src/datagrid/toolbar/SearchField.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import InputGroup from "react-bootstrap/lib/InputGroup";
 import TextInput from "../../inputs/TextInput";
@@ -11,17 +12,17 @@ export default class SearchField extends ShallowComponent {
         /**
          *Value for the search
          */
-        value: React.PropTypes.string,
+        value: PropTypes.string,
 
         /**
-         * placeholder text 
+         * placeholder text
          */
-        placeholder: React.PropTypes.string,
+        placeholder: PropTypes.string,
 
         /**
          *Delay between last keystroke and search request.
          */
-        delay: React.PropTypes.number
+        delay: PropTypes.number
 
     };
     static defaultProps = {

--- a/src/extras/Iconizer.jsx
+++ b/src/extras/Iconizer.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent, Application } from "robe-react-commons";
 import FaIcon from "../faicon/FaIcon";
 
@@ -8,11 +9,11 @@ export default class Iconizer extends ShallowComponent {
         /**
          * Links array
          */
-        links: React.PropTypes.array,
+        links: PropTypes.array,
         /**
          * Icons size
          */
-        size: React.PropTypes.oneOf(["sm", "lg", "2x", "3x", "4x", "5x"])
+        size: PropTypes.oneOf(["sm", "lg", "2x", "3x", "4x", "5x"])
     };
 
     static defaultProps = {

--- a/src/faicon/FaIcon.jsx
+++ b/src/faicon/FaIcon.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent } from "robe-react-commons";
 import "font-awesome/css/font-awesome.min.css";
 
@@ -13,21 +14,21 @@ export default class FaIcon extends ShallowComponent {
          * Classname for use icon.
          * More information : http://fontawesome.io/icons/
          */
-        code: React.PropTypes.string.isRequired,
+        code: PropTypes.string.isRequired,
         /**
          * Size code of the icon. Use fa-sm, fa-lg (33% increase), fa-2x, fa-3x, fa-4x, or fa-5x classes.
          * More information : http://fontawesome.io/examples/#larger
          */
-        size: React.PropTypes.oneOf(["fa-sm", "fa-lg", "fa-2x", "fa-3x", "fa-4x", "fa-5x"]),
+        size: PropTypes.oneOf(["fa-sm", "fa-lg", "fa-2x", "fa-3x", "fa-4x", "fa-5x"]),
         /**
          * applies custom style to the icon.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Specifies to use fa-fw class or not for fixed icon width and height.
          * More information : http://fontawesome.io/examples/#fixed-width
          */
-        fixed: React.PropTypes.bool
+        fixed: PropTypes.bool
     };
 
     static defaultProps = {

--- a/src/form/DataForm.jsx
+++ b/src/form/DataForm.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Maps, Objects, Assertions} from "robe-react-commons";
 import {Form, Row, Col} from "react-bootstrap";
 import ComponentManager from "./ComponentManager";
@@ -13,35 +14,35 @@ export default class DataForm extends ShallowComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Holds field properties like `name`, `label`, `type`, `visible`, `editable`, `readable`, `label`
          */
-        fields: React.PropTypes.array.isRequired,
+        fields: PropTypes.array.isRequired,
         /**
          * Holds extra props of components if need.
          */
-        propsOfFields: React.PropTypes.object,
+        propsOfFields: PropTypes.object,
         /**
          * Form is collapsible or not
          */
-        collapsible: React.PropTypes.bool,
+        collapsible: PropTypes.bool,
         /**
          * Form is defaultExpanded or not
          */
-        defaultExpanded: React.PropTypes.bool,
+        defaultExpanded: PropTypes.bool,
         /**
          * Form side by side input columns size
          */
-        columnsSize: React.PropTypes.oneOf([1, 2, 3, 4, 6, 12]),
+        columnsSize: PropTypes.oneOf([1, 2, 3, 4, 6, 12]),
         /**
          * Map of the default values for the component.
          */
-        defaultValues: React.PropTypes.object,
+        defaultValues: PropTypes.object,
         /**
          *Defines the display style of the Validation message.
          */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"])
+        validationDisplay: PropTypes.oneOf(["overlay", "block"])
     };
 
     /**

--- a/src/form/ModalConfirm.jsx
+++ b/src/form/ModalConfirm.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {
     ShallowComponent,
     Application
@@ -9,13 +10,13 @@ import Button from "react-bootstrap/lib/Button";
 export default class ModalConfirm extends ShallowComponent {
 
     static propTypes = {
-        onOkClick: React.PropTypes.func,
-        onCancelClick: React.PropTypes.func,
-        header: React.PropTypes.string,
-        message: React.PropTypes.string,
-        show: React.PropTypes.bool,
-        ok: React.PropTypes.string,
-        cancel: React.PropTypes.string,
+        onOkClick: PropTypes.func,
+        onCancelClick: PropTypes.func,
+        header: PropTypes.string,
+        message: PropTypes.string,
+        show: PropTypes.bool,
+        ok: PropTypes.string,
+        cancel: PropTypes.string,
     };
 
 

--- a/src/form/ModalDataForm.jsx
+++ b/src/form/ModalDataForm.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {
     ShallowComponent,
     Application
@@ -21,37 +22,37 @@ export default class ModalDataForm extends ShallowComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Header for the form control.
          */
-        header: React.PropTypes.string,
+        header: PropTypes.string,
         /**
          * Hold data in a map
          */
-        defaulValues: React.PropTypes.object,
+        defaulValues: PropTypes.object,
         /**
          * Holds field properties like `name`, `label`, `type`, `visible`, `editable`, `readable`, `label`
          */
-        fields: React.PropTypes.array.isRequired,
+        fields: PropTypes.array.isRequired,
         /**
          * Holds extra props of components if need.
          */
-        propsOfFields: React.PropTypes.object,
+        propsOfFields: PropTypes.object,
         /**
          * Holds Component props and component if need.
          */
-        show: React.PropTypes.bool,
-        onSubmit: React.PropTypes.func.isRequired,
-        onCancel: React.PropTypes.func,
-        cancel: React.PropTypes.string,
-        ok: React.PropTypes.string,
-        showCancelButton: React.PropTypes.bool,
-        showSaveButton: React.PropTypes.bool,
+        show: PropTypes.bool,
+        onSubmit: PropTypes.func.isRequired,
+        onCancel: PropTypes.func,
+        cancel: PropTypes.string,
+        ok: PropTypes.string,
+        showCancelButton: PropTypes.bool,
+        showSaveButton: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"])
+        validationDisplay: PropTypes.oneOf(["overlay", "block"])
     };
 
     /**

--- a/src/googlemap/BounceMarker.jsx
+++ b/src/googlemap/BounceMarker.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import OverlayTrigger from "react-bootstrap/lib/OverlayTrigger";
 import Popover from "react-bootstrap/lib/Popover";
@@ -9,14 +10,14 @@ import "./GoogleMap.css";
 export default class BounceMarker extends ShallowComponent {
 
     static propTypes = {
-        lat: React.PropTypes.number.isRequired,
-        lng: React.PropTypes.number.isRequired,
-        description: React.PropTypes.string,
-        inputType: React.PropTypes.oneOf(["textInput", "textArea", "none"]),
-        inputStyle: React.PropTypes.object,
-        overlay: React.PropTypes.bool,
-        overlayPlacement: React.PropTypes.oneOf(["top", "right", "left", "bottom"]),
-        overlayStyle: React.PropTypes.object
+        lat: PropTypes.number.isRequired,
+        lng: PropTypes.number.isRequired,
+        description: PropTypes.string,
+        inputType: PropTypes.oneOf(["textInput", "textArea", "none"]),
+        inputStyle: PropTypes.object,
+        overlay: PropTypes.bool,
+        overlayPlacement: PropTypes.oneOf(["top", "right", "left", "bottom"]),
+        overlayStyle: PropTypes.object
     };
 
     static defaultProps = {

--- a/src/googlemap/GoogleMap.jsx
+++ b/src/googlemap/GoogleMap.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent, Application } from "robe-react-commons";
 import Googlemap from "google-map-react";
 import SearchBox from "./SearchBox";
@@ -9,7 +10,7 @@ export default class GoogleMap extends ShallowComponent {
 
     static propTypes: Map = {
         ...Googlemap.PropTypes,
-        searchBox: React.PropTypes.object
+        searchBox: PropTypes.object
     };
 
     static defaultProps = {

--- a/src/googlemap/SearchBox.jsx
+++ b/src/googlemap/SearchBox.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import {
     ShallowComponent,
     Application
@@ -8,8 +9,8 @@ import TextInput from "../inputs/TextInput";
 export default class SearchBox extends ShallowComponent {
 
     static propTypes = {
-        placeholder: React.PropTypes.string,
-        apiParams: React.PropTypes.object.isRequired
+        placeholder: PropTypes.string,
+        apiParams: PropTypes.object.isRequired
     };
 
     static defaultProps = {

--- a/src/image/LazyImage.jsx
+++ b/src/image/LazyImage.jsx
@@ -1,11 +1,12 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { ShallowComponent } from "robe-react-commons";
 import BImage from "react-bootstrap/lib/Image";
 import "./LazyImage.css";
 /**
  * LazyImage is a component for loading images via ajax with a loading animation.
- * 
+ *
  * @export
  * @class LazyImage
  * @extends {ShallowComponent}
@@ -16,42 +17,42 @@ export default class LazyImage extends ShallowComponent {
         /**
          *Source of the image
          */
-        src: React.PropTypes.string.isRequired,
+        src: PropTypes.string.isRequired,
         /**
          *Height of the image
          */
-        height: React.PropTypes.string.isRequired,
+        height: PropTypes.string.isRequired,
         /**
          * Width of the image
          */
-        width: React.PropTypes.string.isRequired,
+        width: PropTypes.string.isRequired,
 
         /**
          * Applies custom style to the image.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
 
         /**
          *Sets image shape as circle
         */
-        circle: React.PropTypes.bool,
+        circle: PropTypes.bool,
 
         /** Sets image as responsive image */
-        responsive: React.PropTypes.bool,
+        responsive: PropTypes.bool,
 
         /** Sets image shape as rounded */
-        rounded: React.PropTypes.bool,
+        rounded: PropTypes.bool,
 
         /** Sets image shape as thumbnail */
-        thumbnail: React.PropTypes.bool,
+        thumbnail: PropTypes.bool,
 
     };
 
     /**
-     * 
-     * 
+     *
+     *
      * @static
-     * 
+     *
      * @memberOf LazyImage
      */
     static defaultProps = {

--- a/src/inputs/BaseInput.jsx
+++ b/src/inputs/BaseInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { FormGroup, InputGroup, ControlLabel, FormControl, OverlayTrigger, Tooltip } from "react-bootstrap";
 import ReactDOM from "react-dom";
 import ValidationComponent from "../validation/ValidationComponent";
@@ -18,55 +19,55 @@ export default class BaseInput extends ValidationComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.any,
+        value: PropTypes.any,
         /**
          * Validations for the component
          */
-        validations: React.PropTypes.object,
+        validations: PropTypes.object,
         /**
          * Type of the BaseInput. (text, email, password, file)
          */
-        type: React.PropTypes.string,
+        type: PropTypes.string,
         /**
          * Component class of the BaseInput. (select, textarea)
          */
-        componentClass: React.PropTypes.string,
+        componentClass: PropTypes.string,
         /**
         * Left Input Addon
         */
-        inputGroupLeft: React.PropTypes.any,
+        inputGroupLeft: PropTypes.any,
         /**
         * Right Input Addon
         */
-        inputGroupRight: React.PropTypes.any,
+        inputGroupRight: PropTypes.any,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
          *Defines the display style of the Validation message.
          */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"])
+        validationDisplay: PropTypes.oneOf(["overlay", "block"])
     };
 
     /**

--- a/src/inputs/CheckInput.jsx
+++ b/src/inputs/CheckInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { FormGroup, ControlLabel } from "react-bootstrap";
 import ValidationComponent from "../validation/ValidationComponent";
 import FaIcon from "../faicon/FaIcon";
@@ -19,66 +20,66 @@ export default class CheckInput extends ValidationComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Array of items. All items will be rendered as separate checkbox input.
          */
-        items: React.PropTypes.array,
+        items: PropTypes.array,
         /**
          * Item will be rendered checkbox input single.
          */
-        item: React.PropTypes.object,
+        item: PropTypes.object,
         /**
          * Checked value or values
          */
-        value: React.PropTypes.oneOfType([
-            React.PropTypes.bool,
-            React.PropTypes.array
+        value: PropTypes.oneOfType([
+            PropTypes.bool,
+            PropTypes.array
         ]),
         /**
          * Key of map item which is defined in given array `items`
          */
-        valueField: React.PropTypes.any,
+        valueField: PropTypes.any,
         /**
          * label of map item which is defined in given array `items`
          */
-        textField: React.PropTypes.string,
+        textField: PropTypes.string,
         /**
          * onChange callback function when selection `item` or `items` changed.
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Validations functions to validate value
          */
-        validations: React.PropTypes.object,
+        validations: PropTypes.object,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
          * Defines class of the check input. (form-control or not)
          */
-        formControl: React.PropTypes.bool
+        formControl: PropTypes.bool
     };
 
 

--- a/src/inputs/DateInput.jsx
+++ b/src/inputs/DateInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Application} from "robe-react-commons";
 import momentjs from "moment";
 import is from "is-js";
@@ -26,38 +27,38 @@ export default class DateInput extends ShallowComponent {
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.oneOfType([
-            React.PropTypes.string,
-            React.PropTypes.number]),
+        value: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number]),
         /**
          * onChangeEvent event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
 
         /**
          * Date formatting of the component.
          */
-        format: React.PropTypes.oneOf([
+        format: PropTypes.oneOf([
             "DD/MM/YYYY", "MM/DD/YYYY", "YYYY/MM/DD",
             "DD-MM-YYYY", "MM-DD-YYYY", "YYYY-MM-DD",
             "DD.MM.YYYY", "MM.DD.YYYY", "YYYY.MM.DD",
@@ -66,19 +67,19 @@ export default class DateInput extends ShallowComponent {
         /**
          *Minimum date to show at the picker.
          */
-        minDate: React.PropTypes.number,
+        minDate: PropTypes.number,
         /**
          *Maximum date to show at the picker.
          */
-        maxDate: React.PropTypes.number,
+        maxDate: PropTypes.number,
         /**
          *Defines the display style of the Validation message.
          */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
          * Left Input Addon
          */
-        inputGroupLeft: React.PropTypes.object
+        inputGroupLeft: PropTypes.object
 
     };
 

--- a/src/inputs/DecimalInput.jsx
+++ b/src/inputs/DecimalInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import { InputGroup } from "react-bootstrap";
 import Input from "./BaseInput";
@@ -22,51 +23,51 @@ export default class DecimalInput extends ShallowComponent {
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.any,
+        value: PropTypes.any,
         /**
          * increment and decrement number
          */
-        step: React.PropTypes.number,
+        step: PropTypes.number,
         /**
          * onChange event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Decimal Seperator for integer and fraction.
          */
-        decimalSeparator: React.PropTypes.oneOf([".", ","]),
+        decimalSeparator: PropTypes.oneOf([".", ","]),
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
         * Left Input Addon
         */
-        inputGroupLeft: React.PropTypes.object,
+        inputGroupLeft: PropTypes.object,
         /**
         * Right Input Addon
         */
-        inputGroupRight: React.PropTypes.object
+        inputGroupRight: PropTypes.object
     };
 
     /**

--- a/src/inputs/MoneyInput.jsx
+++ b/src/inputs/MoneyInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import InputGroup from "react-bootstrap/lib/InputGroup";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Input from "./BaseInput";
@@ -13,53 +14,53 @@ export default class MoneyInput extends ShallowComponent {
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.any.isRequired,
+        value: PropTypes.any.isRequired,
         /**
          * onChange event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Unit for the currency. Will be displayed right side of the input.
          */
-        unit: React.PropTypes.oneOf(["TL", "EUR", "USD"]),
+        unit: PropTypes.oneOf(["TL", "EUR", "USD"]),
 
         /**
          * Decimal Separator for integer and fraction.
          */
-        decimalSeparator: React.PropTypes.oneOf([".", ","]),
+        decimalSeparator: PropTypes.oneOf([".", ","]),
 
         /**
          * Thousand Separator for integer and fraction.
          */
-        thousandSeparator: React.PropTypes.oneOf([".", ","]),
+        thousandSeparator: PropTypes.oneOf([".", ","]),
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
        * Left Input Addon
        */
-        inputGroupLeft: React.PropTypes.object
+        inputGroupLeft: PropTypes.object
 
     };
 

--- a/src/inputs/NumericInput.jsx
+++ b/src/inputs/NumericInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import is from "is-js";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Input from "./BaseInput";
@@ -21,43 +22,43 @@ export default class NumericInput extends ShallowComponent {
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.any,
+        value: PropTypes.any,
         /**
          * onChange event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
        * Left Input Addon
        */
-        inputGroupLeft: React.PropTypes.object,
+        inputGroupLeft: PropTypes.object,
         /**
         * Right Input Addon
         */
-        inputGroupRight: React.PropTypes.object
+        inputGroupRight: PropTypes.object
     };
 
     /**

--- a/src/inputs/PasswordInput.jsx
+++ b/src/inputs/PasswordInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent, Application } from "robe-react-commons";
 import { InputGroup } from "react-bootstrap";
 import zxcvbn from 'zxcvbn';
@@ -21,47 +22,47 @@ export default class PasswordInput extends ShallowComponent {
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.any.isRequired,
+        value: PropTypes.any.isRequired,
         /**
          * onChange event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
        * Left Input Addon
        */
-        inputGroupLeft: React.PropTypes.any,
+        inputGroupLeft: PropTypes.any,
         /**
         * Right Input Addon
         */
-        inputGroupRight: React.PropTypes.any,
+        inputGroupRight: PropTypes.any,
         /**
         * it specifies that a password strength is hidden or visible
         */
-        strength: React.PropTypes.bool
+        strength: PropTypes.bool
     };
 
     innerComponent;

--- a/src/inputs/RadioInput.jsx
+++ b/src/inputs/RadioInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {Assertions} from "robe-react-commons";
 import {FormGroup, ControlLabel} from "react-bootstrap";
 import ValidationComponent from "../validation/ValidationComponent";
@@ -19,61 +20,61 @@ export default class RadioInput extends ValidationComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Items will be rendered as radio input.
          */
-        items: React.PropTypes.oneOfType([
-            React.PropTypes.object,
-            React.PropTypes.array]),
+        items: PropTypes.oneOfType([
+            PropTypes.object,
+            PropTypes.array]),
         /**
          * Checked value or values
          */
-        value: React.PropTypes.string,
+        value: PropTypes.string,
         /**
          * Key of map item which is defined in given array `items`
          */
-        valueField: React.PropTypes.any,
+        valueField: PropTypes.any,
         /**
          * label of map item which is defined in given array `items`
          */
-        textField: React.PropTypes.string,
+        textField: PropTypes.string,
         /**
          * Is a callback function when selection `item` or `items` changed.
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Validations functions to validate value
          */
-        validations: React.PropTypes.object,
+        validations: PropTypes.object,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
          * it specifies that an radios will be horizontal or not.
          */
-        horizontal: React.PropTypes.bool,
+        horizontal: PropTypes.bool,
         /**
          *Defines the display style of the Validation message.
          */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"])
+        validationDisplay: PropTypes.oneOf(["overlay", "block"])
     };
 
     /**

--- a/src/inputs/SelectInput.jsx
+++ b/src/inputs/SelectInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import {FormGroup, FormControl, ControlLabel, Col} from "react-bootstrap";
 import {Application, Arrays} from "robe-react-commons";
@@ -17,74 +18,74 @@ export default class SelectInput extends ValidationComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name for the input name
          */
-        code: React.PropTypes.string,
+        code: PropTypes.string,
         /**
          * map array of options to render.
          */
-        items: React.PropTypes.array,
+        items: PropTypes.array,
         /**
          * Selected value or values
          */
-        value: React.PropTypes.oneOfType([
-            React.PropTypes.string,
-            React.PropTypes.array
+        value: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.array
         ]),
         /**
          * key of given map array `items`
          */
-        valueField: React.PropTypes.any,
+        valueField: PropTypes.any,
         /**
          * presented text of give map array `items`
          */
-        textField: React.PropTypes.string,
+        textField: PropTypes.string,
         /**
          * displayed when there"s no value
          */
-        placeholder: React.PropTypes.string,
+        placeholder: PropTypes.string,
         /**
          * callback function when selected values changed
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Validations for the component
          */
-        validations: React.PropTypes.object,
+        validations: PropTypes.object,
         /**
          * Check List is single or multi
          */
-        multi: React.PropTypes.bool,
+        multi: PropTypes.bool,
         /**
          * presented message if any result not shown.
          */
-        noResult: React.PropTypes.string,
+        noResult: PropTypes.string,
         /**
          *  whether to enable searching feature or not
          */
-        searchable: React.PropTypes.bool,
+        searchable: PropTypes.bool,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
          *Defines the display style of the Validation message.
          */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
          *
          */
-        disabledValues: React.PropTypes.array
+        disabledValues: PropTypes.array
     };
 
     static defaultProps = {

--- a/src/inputs/TextArea.jsx
+++ b/src/inputs/TextArea.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { findDOMNode } from "react-dom";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Input from "./BaseInput";
@@ -19,47 +20,47 @@ export default class TextArea extends ShallowComponent {
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.string,
+        value: PropTypes.string,
         /**
          * onChangeEvent event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         * it specifies that an input field height be auto resize
         */
-        autoResize: React.PropTypes.bool,
+        autoResize: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
        * Left Input Addon
        */
-        inputGroupLeft: React.PropTypes.object,
+        inputGroupLeft: PropTypes.object,
         /**
         * Right Input Addon
         */
-        inputGroupRight: React.PropTypes.object
+        inputGroupRight: PropTypes.object
     };
 
     /**

--- a/src/inputs/TextInput.jsx
+++ b/src/inputs/TextInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Input from "./BaseInput";
 
@@ -19,43 +20,43 @@ export default class TextInput extends ShallowComponent {
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.string,
+        value: PropTypes.string,
         /**
          * onChangeEvent event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
         *Defines the display style of the Validation message.
         */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
         * Left Input Addon
         */
-        inputGroupLeft: React.PropTypes.object,
+        inputGroupLeft: PropTypes.object,
         /**
         * Right Input Addon
         */
-        inputGroupRight: React.PropTypes.object
+        inputGroupRight: PropTypes.object
     };
 
     /**

--- a/src/inputs/datepicker/DatePicker.jsx
+++ b/src/inputs/datepicker/DatePicker.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import {
     Table,
@@ -14,44 +15,44 @@ export default class DatePicker extends ShallowComponent {
         /**
          * Value of the component
          */
-        value: React.PropTypes.number,
+        value: PropTypes.number,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string,
+        name: PropTypes.string,
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * Change event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Select event for the component. Triggered at date select.
          */
-        onSelect: React.PropTypes.func,
+        onSelect: PropTypes.func,
 
         /**
          * Minimum date to show at the picker.
          */
-        minDate: React.PropTypes.number,
+        minDate: PropTypes.number,
         /**
          * Maximum date to show at the picker.
          */
-        maxDate: React.PropTypes.number,
+        maxDate: PropTypes.number,
 
         /**
          *  Max width of component
          */
-        maxWidth: React.PropTypes.oneOfType([
-            React.PropTypes.string,
-            React.PropTypes.number]),
+        maxWidth: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.number]),
 
         /**
          *  Base CSS class and prefix for the component
          */
-        className: React.PropTypes.string
+        className: PropTypes.string
     };
 
     /**

--- a/src/inputs/htmleditor/HtmlEditor.jsx
+++ b/src/inputs/htmleditor/HtmlEditor.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { findDOMNode } from "react-dom";
 import ReactQuill from "react-quill";
 import { FormGroup, ControlLabel, Col, FormControl } from "react-bootstrap";
@@ -20,53 +21,53 @@ export default class HtmlEditor extends ValidationComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * Value of the component
          */
-        value: React.PropTypes.string,
+        value: PropTypes.string,
         /**
          * handleChange event for the component
          */
-        handleChange: React.PropTypes.func,
+        handleChange: PropTypes.func,
         /**
          * Validations for the component
          */
-        validations: React.PropTypes.object,
+        validations: PropTypes.object,
         /**
          * Height of the component.
          */
-        height: React.PropTypes.number,
+        height: PropTypes.number,
         /**
          * Disable input
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * it specifies that an input field is read-only
          */
-        readOnly: React.PropTypes.bool,
+        readOnly: PropTypes.bool,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
 
         /**
         * it specifies that an input field height be auto resize
         */
-        autoResize: React.PropTypes.bool,
+        autoResize: PropTypes.bool,
         /**
        *Defines the display style of the Validation message.
        */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
 
         /**
          *Defines the view mode of the editor.
          */
-        sourceView: React.PropTypes.bool
+        sourceView: PropTypes.bool
     };
 
     /**

--- a/src/inputs/screenkeyboard/ScreenKeyboard.jsx
+++ b/src/inputs/screenkeyboard/ScreenKeyboard.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Button from "react-bootstrap/lib/Button";
 import QKeyboard_en_US from "./QKeyboard_en_US.json";
@@ -21,43 +22,43 @@ export default class ScreenKeyboard extends ShallowComponent {
         /**
          * Input component to be worked on (Needs input's ID field)
          */
-        inputId: React.PropTypes.string,
+        inputId: PropTypes.string,
         /**
          * Keyboard buttons language.
          */
-        language: React.PropTypes.oneOf([
+        language: PropTypes.oneOf([
             "en_US", "tr_TR", "ru_RU", "numeric", "decimal"
         ]),
         /**
          * Change event for the component (Returns (e, currentValue))
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * Default display of ScreenKeyboard component (works only if has true inputID)
          */
-        defaultShow: React.PropTypes.bool,
+        defaultShow: PropTypes.bool,
         /**
          * Displays your text top of Keyboard component
          */
-        languageText: React.PropTypes.string,
+        languageText: PropTypes.string,
         /**
          * Decimal seperator for DecimalInput (Works only with decimal keyboard)
          */
-        decimalSeperator: React.PropTypes.oneOf([
+        decimalSeperator: PropTypes.oneOf([
             ",", "."
         ]),
         /**
          * Changes inputs value automatically (But it does not reflect the situation)
          */
-        changeValueAutomatically: React.PropTypes.bool,
+        changeValueAutomatically: PropTypes.bool,
         /**
          * Style of Keyboard container
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Display configuration on mobile devices
          */
-        showOnMobile: React.PropTypes.bool
+        showOnMobile: PropTypes.bool
     };
 
     /**

--- a/src/inputs/upload/FileUploadInput.jsx
+++ b/src/inputs/upload/FileUploadInput.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { findDOMNode } from "react-dom";
 import { Generator, Application, Objects, Maps, Arrays } from "robe-react-commons";
 import { FormGroup, FormControl, ControlLabel, Glyphicon, Checkbox, OverlayTrigger, Tooltip } from "react-bootstrap";
@@ -38,70 +39,70 @@ export default class FileUploadInput extends ValidationComponent {
         /**
          * Style map for the component.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * name use as input field name
          */
-        name: React.PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
         /**
          * Label for the form control.
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * File Id List or File Name
          */
-        value: React.PropTypes.oneOfType([
-            React.PropTypes.string,
-            React.PropTypes.arrayOf(React.PropTypes.string)
+        value: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.arrayOf(PropTypes.string)
         ]),
         /**
          * onChangeEvent event for the component
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * describe Selection File Multi or Single
          */
-        multiple: React.PropTypes.bool,
+        multiple: PropTypes.bool,
         /**
          * Style map for the component.
          */
-        itemStyle: React.PropTypes.object,
+        itemStyle: PropTypes.object,
         /**
          * Item show renderer
          */
-        itemRenderer: React.PropTypes.func,
+        itemRenderer: PropTypes.func,
         /**
          * File Input Form Control Place Holder
          */
-        placeholder: React.PropTypes.string,
+        placeholder: PropTypes.string,
         /**
          * it specifies that an input field is hidden or visible
          */
-        hidden: React.PropTypes.bool,
+        hidden: PropTypes.bool,
         /**
          * auto upload is false then file will upload when clicking the upload button.
          */
-        autoUpload: React.PropTypes.bool,
+        autoUpload: PropTypes.bool,
         /**
          *
          */
-        remote: React.PropTypes.object,
+        remote: PropTypes.object,
         /**
          *
          */
-        toolbarPosition: React.PropTypes.string,
+        toolbarPosition: PropTypes.string,
         /**
          * Max Uploaded file
          */
-        maxFileSize: React.PropTypes.number,
+        maxFileSize: PropTypes.number,
         /**
          *Defines the display style of the Validation message.
          */
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"]),
+        validationDisplay: PropTypes.oneOf(["overlay", "block"]),
         /**
          * Define file input accept extensions
          */
-        accept: React.PropTypes.string
+        accept: PropTypes.string
     };
 
     static defaultProps = {
@@ -512,4 +513,3 @@ export default class FileUploadInput extends ValidationComponent {
         this.setState(state);
     }
 }
-

--- a/src/layouts/DragDropLayout.jsx
+++ b/src/layouts/DragDropLayout.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent } from "robe-react-commons";
 import {findDOMNode} from "react-dom";
 import { Generator } from "robe-react-commons";
@@ -21,19 +22,19 @@ export default class DragDropLayout extends ShallowComponent {
         /**
          * Used to change current styles of DragDropLayout.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * if layout container clicked then triggered.
          */
-        onClick: React.PropTypes.func,
+        onClick: PropTypes.func,
         /**
          * when a draggable element is dropped in the layout container element.
          */
-        onDrop: React.PropTypes.func,
+        onDrop: PropTypes.func,
         /**
          * Used to change the styles of the DragDropLayout  when anything dragged  on.
          */
-        draggedStyle: React.PropTypes.object,
+        draggedStyle: PropTypes.object,
     };
 
     __componentId;

--- a/src/layouts/EventLayout.jsx
+++ b/src/layouts/EventLayout.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent } from "robe-react-commons";
 
 export default class EventLayout extends ShallowComponent {
@@ -12,27 +13,27 @@ export default class EventLayout extends ShallowComponent {
         /**
          * The onclick event occurs when the element clicked.
          */
-        onClick: React.PropTypes.func,
+        onClick: PropTypes.func,
         /**
          * The ondrop event occurs when a draggable element or text selection is dropped on a valid drop target.
          */
-        onDrop: React.PropTypes.func,
+        onDrop: PropTypes.func,
         /**
          * The onDragLeave event occurs when a draggable element or text selection leaves a valid drop target.
          */
-        onDragLeave: React.PropTypes.func,
+        onDragLeave: PropTypes.func,
         /**
          * when an element is being dragged over the layout container element.
          */
-        onDragOver: React.PropTypes.func,
+        onDragOver: PropTypes.func,
         /**
          * when a draggable element enters the layout container element.
          */
-        onDragEnter: React.PropTypes.func,
+        onDragEnter: PropTypes.func,
         /**
          * when the user starts to drag the layout container element.
          */
-        onDragStart: React.PropTypes.func
+        onDragStart: PropTypes.func
     };
 
     constructor(props: Object) {

--- a/src/layouts/RadiusPanelGroup.jsx
+++ b/src/layouts/RadiusPanelGroup.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent } from "robe-react-commons";
 import "./RadiusPanelGroup.css";
 
@@ -9,12 +10,12 @@ export default class RadiusPanelGroup extends ShallowComponent {
      * @static
      */
     static propTypes: Map = {
-        label: React.PropTypes.string,
-        style: React.PropTypes.object,
-        itemStyle: React.PropTypes.object,
-        items: React.PropTypes.array,
-        renderItem: React.PropTypes.func,
-        onClose: React.PropTypes.func
+        label: PropTypes.string,
+        style: PropTypes.object,
+        itemStyle: PropTypes.object,
+        items: PropTypes.array,
+        renderItem: PropTypes.func,
+        onClose: PropTypes.func
     };
 
     /**

--- a/src/layouts/StackLayout.jsx
+++ b/src/layouts/StackLayout.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent, Assertions } from "robe-react-commons";
 import { Panel, Row, Col, Glyphicon } from "react-bootstrap";
 import "./StackLayout.css";
@@ -14,59 +15,59 @@ export default class StackLayout extends ShallowComponent {
         /**
          * Presentation mode list or thumbnail.
          */
-        display: React.PropTypes.oneOf(["list", "thumbnail"]),
+        display: PropTypes.oneOf(["list", "thumbnail"]),
         /**
          * Header of Layout
          */
-        label: React.PropTypes.string,
+        label: PropTypes.string,
         /**
          * Layout Container style
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * will Shown given items which type is an array
          */
-        items: React.PropTypes.array,
+        items: PropTypes.array,
         /**
          * Add Toolbar to layout . Default position is bottom
          */
-        toolbar: React.PropTypes.object,
+        toolbar: PropTypes.object,
         /**
          * toolbar position
          */
-        toolbarPosition: React.PropTypes.oneOf(["bottom", "top", "left", "right"]),
+        toolbarPosition: PropTypes.oneOf(["bottom", "top", "left", "right"]),
         /**
          * render item by class which is using this layout.
          */
-        onItemRender: React.PropTypes.func,
+        onItemRender: PropTypes.func,
         /**
          * if layout container clicked then triggered.
          */
-        onClick: React.PropTypes.func,
+        onClick: PropTypes.func,
         /**
          * if any item selection changed.
          */
-        onItemClick: React.PropTypes.func,
+        onItemClick: PropTypes.func,
         /**
          * when a draggable element is dropped in the layout container element.
          */
-        onDrop: React.PropTypes.func,
+        onDrop: PropTypes.func,
         /**
          * when a draggable element is moved out of the layout container element.
          */
-        onDragLeave: React.PropTypes.func,
+        onDragLeave: PropTypes.func,
         /**
          * when an element is being dragged over the layout container element.
          */
-        onDragOver: React.PropTypes.func,
+        onDragOver: PropTypes.func,
         /**
          * when a draggable element enters the layout container element.
          */
-        onDragEnter: React.PropTypes.func,
+        onDragEnter: PropTypes.func,
         /**
          * when the user starts to drag the layout container element.
          */
-        onDragStart: React.PropTypes.func
+        onDragStart: PropTypes.func
 
     };
 

--- a/src/layouts/ThumbnailGroup.jsx
+++ b/src/layouts/ThumbnailGroup.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {Clearfix} from "react-bootstrap";
 import ThumbnailItem from "./ThumbnailItem";
 import {ShallowComponent} from "robe-react-commons";
@@ -11,10 +12,10 @@ export default class ThumbnailGroup extends ShallowComponent {
      * @static
      */
     static propTypes:Map = {
-        id: React.PropTypes.string,
-        style: React.PropTypes.object,
-        className: React.PropTypes.string,
-        placeholder: React.PropTypes.string
+        id: PropTypes.string,
+        style: PropTypes.object,
+        className: PropTypes.string,
+        placeholder: PropTypes.string
     };
 
     constructor(props:Object) {

--- a/src/layouts/ThumbnailItem.jsx
+++ b/src/layouts/ThumbnailItem.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {Glyphicon} from "react-bootstrap";
 import {ShallowComponent} from "robe-react-commons";
 import ProgressBar from "../progress/ProgressBar"
@@ -11,11 +12,11 @@ export default class ThumbnailItem extends ShallowComponent {
      * @static
      */
     static propTypes:Map = {
-        className: React.PropTypes.string,
-        style: React.PropTypes.object,
-        focused: React.PropTypes.bool,
-        selected: React.PropTypes.bool,
-        loading: React.PropTypes.bool
+        className: PropTypes.string,
+        style: PropTypes.object,
+        focused: PropTypes.bool,
+        selected: PropTypes.bool,
+        loading: PropTypes.bool
     };
 
     /**

--- a/src/notification/Notification.jsx
+++ b/src/notification/Notification.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import { ShallowComponent, Application } from "robe-react-commons";
 import Col from "react-bootstrap/lib/Col";
@@ -26,15 +27,15 @@ export default class Notification extends ShallowComponent {
          * Click event for the notification details.
          * Footer link will be rendered according to this property.
          */
-        detailsClick: React.PropTypes.func,
+        detailsClick: PropTypes.func,
         /**
          * Text for the notification details link.
          */
-        detailsText: React.PropTypes.string,
+        detailsText: PropTypes.string,
         /**
          * Title for the notification popup.
          */
-        title: React.PropTypes.string,
+        title: PropTypes.string,
     };
 
     static defaultProps = {

--- a/src/notification/NotificationItem.jsx
+++ b/src/notification/NotificationItem.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent } from "robe-react-commons";
 import Col from "react-bootstrap/lib/Col";
 import moment from "moment";
@@ -6,7 +7,7 @@ import moment from "moment";
 export default class NotificationItem extends ShallowComponent {
 
     static propTypes = {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     };
 
     render(): Object {

--- a/src/progress/ProgressBar.jsx
+++ b/src/progress/ProgressBar.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent} from "robe-react-commons";
 import ClassName from "../util/css/ClassName";
 import "./ProgressBar.css"
@@ -12,15 +13,15 @@ export default class ProgressBar extends ShallowComponent {
         /**
          *  Classname for use progress.
          */
-        className: React.PropTypes.string,
+        className: PropTypes.string,
         /**
          * Custom style to the progress.
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Specifies status for progress.
          */
-        loading: React.PropTypes.bool
+        loading: PropTypes.bool
     };
 
     /**

--- a/src/rating/Rating.jsx
+++ b/src/rating/Rating.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import {ControlLabel} from "react-bootstrap";
 import "./Rating.css";
@@ -9,45 +10,45 @@ export default class Rating extends ShallowComponent {
         /**
          * Size of Rating icons
          */
-        size: React.PropTypes.oneOf([
+        size: PropTypes.oneOf([
             0, 1, 2, 3, 4
         ]),
         /**
          * Direct selected value
          */
-        currentValue: React.PropTypes.number,
+        currentValue: PropTypes.number,
         /**
          * Count of icons
          */
-        iconCount: React.PropTypes.number,
+        iconCount: PropTypes.number,
         /**
          * Initial icon type (Works with font-awesome icons like "fa-star-o")
          */
-        initialIcon: React.PropTypes.string,
+        initialIcon: PropTypes.string,
         /**
          * Selected icon type (Works with font-awesome icons like "fa-star")
          */
-        selectedIcon: React.PropTypes.string,
+        selectedIcon: PropTypes.string,
         /**
          * Disable icons
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * Change event for the component (Returns (clickedKey))
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * MouseOver event for the component (Returns (hoveredKey))
          */
-        onMouseOver: React.PropTypes.func,
+        onMouseOver: PropTypes.func,
         /**
          * Style of Rating icons
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Label for Rating component
          */
-        label: React.PropTypes.string
+        label: PropTypes.string
     };
 
     /**

--- a/src/sidemenu/SideMenu.jsx
+++ b/src/sidemenu/SideMenu.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Arrays from "robe-react-commons/lib/utils/Arrays";
 import FaIcon from "../faicon/FaIcon";
@@ -18,24 +19,24 @@ export default class SideMenu extends ShallowComponent {
         /**
          * Path of the selected item
          */
-        selectedItem: React.PropTypes.string,
+        selectedItem: PropTypes.string,
         /**
          * Items of the menu. Must be a valid json map with a root element.
          */
-        items: React.PropTypes.array.isRequired,
+        items: PropTypes.array.isRequired,
         /**
          * Change event of the sidemenu.
          * It is triggered if the selected sub-item changes, not collapsed menu.
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * key of given map array `items`
          */
-        valueField: React.PropTypes.any,
+        valueField: PropTypes.any,
         /**
          * presented text of give map array `items`
          */
-        textField: React.PropTypes.string,
+        textField: PropTypes.string,
     };
 
     static defaultProps = {

--- a/src/sidepanel/SidePanel.jsx
+++ b/src/sidepanel/SidePanel.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent,Application,Maps} from "robe-react-commons";
 import {Nav, NavItem, InputGroup, Overlay, Popover} from "react-bootstrap";
 import "./SidePanel.css";
@@ -9,19 +10,19 @@ export default class SidePanel extends ShallowComponent {
         /**
          * Is component visible or not
          */
-        visible: React.PropTypes.bool,
+        visible: PropTypes.bool,
         /**
          * Position of the component
          */
-        position: React.PropTypes.oneOf(["left","right"]),
+        position: PropTypes.oneOf(["left","right"]),
         /**
          * Styles that you want to change
          */
-        style: React.PropTypes.object,
+        style: PropTypes.object,
         /**
          * Width in pixels
          */
-        width: React.PropTypes.number
+        width: PropTypes.number
     };
 
     static defaultProps = {

--- a/src/slider/Slider.jsx
+++ b/src/slider/Slider.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import {Popover, Overlay, Tooltip, Col} from "react-bootstrap";
@@ -10,55 +11,55 @@ export default class Slider extends ShallowComponent {
         /**
          * Maximum value of Slider component.
          */
-        maxValue: React.PropTypes.number,
+        maxValue: PropTypes.number,
         /**
          * Minimum value of Slider component.
          */
-        minValue: React.PropTypes.number,
+        minValue: PropTypes.number,
         /**
          * Default value of Slider component (If has range prop defaultValue must array like {[0,100]}).
          */
-        defaultValue: React.PropTypes.number,
+        defaultValue: PropTypes.number,
         /**
          * Increment or decrement of values.
          */
-        step: React.PropTypes.number,
+        step: PropTypes.number,
         /**
          * Disables component.
          */
-        disabled: React.PropTypes.bool,
+        disabled: PropTypes.bool,
         /**
          * Range support for slider component.
          */
-        range: React.PropTypes.bool,
+        range: PropTypes.bool,
         /**
          * Change event for the component.
          */
-        onChange: React.PropTypes.func,
+        onChange: PropTypes.func,
         /**
          * After Change event for the component.
          */
-        onAfterChange: React.PropTypes.func,
+        onAfterChange: PropTypes.func,
         /**
          * Close of min-max labels.
          */
-        closeLabel: React.PropTypes.bool,
+        closeLabel: PropTypes.bool,
         /**
          * Label of maximum value.
          */
-        maxLabel: React.PropTypes.string,
+        maxLabel: PropTypes.string,
         /**
          * Label of minimum value.
          */
-        minLabel: React.PropTypes.string,
+        minLabel: PropTypes.string,
         /**
          * Unit of popover content.
          */
-        unit: React.PropTypes.string,
+        unit: PropTypes.string,
         /**
          * Tooltip support for component.
          */
-        closeTooltip: React.PropTypes.bool
+        closeTooltip: PropTypes.bool
     };
 
     /**

--- a/src/toast/Toast.jsx
+++ b/src/toast/Toast.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ReactDOM from "react-dom";
 import {ShallowComponent, Generator, Class, Arrays, Maps} from "robe-react-commons";
 import ClassName from "../util/css/ClassName";
@@ -27,27 +28,27 @@ class Toast extends ShallowComponent {
          * Desired position of toast to be shown on screen
          * { "top-right", "top-left", "bottom-right", "bottom-left" }
          */
-        position: React.PropTypes.oneOf(["top-right", "top-left", "bottom-right", "bottom-left"]).isRequired,
+        position: PropTypes.oneOf(["top-right", "top-left", "bottom-right", "bottom-left"]).isRequired,
         /**
          * Maximum available number of visible toasts
          */
-        maxVisible: React.PropTypes.number,
+        maxVisible: PropTypes.number,
         /**
          *  Message to be shown on Toast
          */
-        message: React.PropTypes.string,
+        message: PropTypes.string,
         /**
          *  Message to be shown on Toast
          */
-        title: React.PropTypes.string,
+        title: PropTypes.string,
         /**
          *  Display time of toast
          */
-        timeOut: React.PropTypes.number,
+        timeOut: PropTypes.number,
         /**
          *  Function to be called when toast is clicked
          */
-        onClick: React.PropTypes.func
+        onClick: PropTypes.func
     };
 
     static defaultProps = {

--- a/src/tree/Tree.jsx
+++ b/src/tree/Tree.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import TreeItem from "./TreeItem";
 import "./Tree.css";
@@ -21,27 +22,27 @@ export default class Tree extends ShallowComponent {
         /**
          * Data for the tree to view
          */
-        items: React.PropTypes.array.isRequired,
+        items: PropTypes.array.isRequired,
         /**
          * Text field of the data
          */
-        textField: React.PropTypes.string,
+        textField: PropTypes.string,
         /**
          * Value field of the data.
          */
-        valueField: React.PropTypes.string,
+        valueField: PropTypes.string,
         /**
          * Children field of the data.
          */
-        childrenField: React.PropTypes.string,
+        childrenField: PropTypes.string,
         /**
          * Checked items array.
          */
-        value: React.PropTypes.array,
+        value: PropTypes.array,
         /**
          * Parent component of the tree item
          */
-        parent: React.PropTypes.object
+        parent: PropTypes.object
 
     };
 

--- a/src/tree/TreeItem.jsx
+++ b/src/tree/TreeItem.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ShallowComponent from "robe-react-commons/lib/components/ShallowComponent";
 import Arrays from "robe-react-commons/lib/utils/Arrays";
 import {ControlLabel} from "react-bootstrap";
@@ -24,23 +25,23 @@ export default class TreeItem extends ShallowComponent {
         /**
          * Data for the tree to view
          */
-        item: React.PropTypes.object.isRequired,
+        item: PropTypes.object.isRequired,
         /**
          * Text field of the data
          */
-        textField: React.PropTypes.string,
+        textField: PropTypes.string,
         /**
          * Value field of the data.
          */
-        valueField: React.PropTypes.string,
+        valueField: PropTypes.string,
         /**
          * Children field of the data.
          */
-        childrenField: React.PropTypes.string,
+        childrenField: PropTypes.string,
         /**
          * Checked items array.
          */
-        value: React.PropTypes.array
+        value: PropTypes.array
 
     };
 

--- a/src/validation/ValidationComponent.jsx
+++ b/src/validation/ValidationComponent.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { ShallowComponent, Maps, Assertions, Objects } from "robe-react-commons";
 import { Alert, OverlayTrigger, Tooltip } from "react-bootstrap";
 import InputValidations from "./InputValidations";
@@ -12,13 +13,13 @@ export default class ValidationComponent extends ShallowComponent {
         /**
          * Value of the component
          */
-        value: React.PropTypes.any,
+        value: PropTypes.any,
         /**
          * Validations for the component
          */
-        validations: React.PropTypes.object,
+        validations: PropTypes.object,
 
-        validationDisplay: React.PropTypes.oneOf(["overlay", "block"])
+        validationDisplay: PropTypes.oneOf(["overlay", "block"])
     };
     /**
      * Max length allowed message.

--- a/src/wizard/Step.jsx
+++ b/src/wizard/Step.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Application, Assertions, Maps} from "robe-react-commons";
 
 export default class Step extends ShallowComponent {
@@ -6,15 +7,15 @@ export default class Step extends ShallowComponent {
         /**
          *
          */
-        title: React.PropTypes.string,
+        title: PropTypes.string,
         /**
          *
          */
-        currentKey: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
+        currentKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         /**
          *
          */
-        index: React.PropTypes.number
+        index: PropTypes.number
     };
 
     static defaultProps = {

--- a/src/wizard/Wizard.jsx
+++ b/src/wizard/Wizard.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import {ShallowComponent, Application, Arrays} from "robe-react-commons";
 import Pager from "react-bootstrap/lib/Pager";
 import Toast from "../toast/Toast";
@@ -16,31 +17,31 @@ export default class Wizard extends ShallowComponent {
         /**
          * Current page index to render.
          */
-        currentKey: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
+        currentKey: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         /**
          * provides to wizard change own state.
          */
-        changeState: React.PropTypes.bool,
+        changeState: PropTypes.bool,
         /**
          * Text for the next button.
          */
-        next: React.PropTypes.string,
+        next: PropTypes.string,
         /**
          * Text for the previous button.
          */
-        previous: React.PropTypes.string,
+        previous: PropTypes.string,
         /**
          * Text for the complete button.
          */
-        complete: React.PropTypes.string,
+        complete: PropTypes.string,
         /**
          *
          */
-        onComplete: React.PropTypes.func,
+        onComplete: PropTypes.func,
         /**
          *
          */
-        onChange: React.PropTypes.func
+        onChange: PropTypes.func
 
     };
 


### PR DESCRIPTION
Re: #00

### What's this PR do?

Replaces the deprecated React.Proptypes with prop-types package

### Changes

- Added prop-types package to package.json
- Imported 'prop-types' package into all components with prop type definitions.
- Replace React.PropTypes with PropTypes in all components.
- Updated keywords.md

